### PR TITLE
Compute median ground elevation in grid cell in EptInPolygons

### DIFF
--- a/src/stepedge_nodes.cpp
+++ b/src/stepedge_nodes.cpp
@@ -2,6 +2,11 @@
 
 #include <lasreader.hpp>
 
+// DEBUG: write polygon WKT with ground height to file
+#include <iostream>
+#include <fstream>
+// end DEBUG
+
 #include <sstream>
 #include <pdal/PointTable.hpp>
 #include <pdal/PointView.hpp>
@@ -2425,8 +2430,15 @@ void EptInPolygonsNode::process()
     }
   }
 
+  // DEBUG: write polygon WKT with ground height to file
+  std::string fout("/tmp/geoflow_footprint_ground.tsv");
+  std::ofstream out_tsv(fout.c_str());
+  std::ostringstream wkt;
+  wkt << "geom" << "\t" << "ground_height" << std::endl;
+  // end DEBUG
+
   // Compute median ground height per grid cell and store it for each polygon
-  std::cout <<"Computing the median ground elevation in the grid cells" << std::endl;
+  std::cout <<"Computing the median ground elevation in the grid cells..." << std::endl;
   for (auto& cell : pindex_vals) {
     std::vector<float> z_vec;
     for (size_t& poly_i : cell) {
@@ -2455,8 +2467,30 @@ void EptInPolygonsNode::process()
     // Assign the median ground elevation to each polygon
     for (size_t& poly_i : cell) {
       ground_heights.get<vec1f>(poly_i).push_back(median);
+
+      // DEBUG: write polygon WKT with ground height to file
+      auto polygon = polygons.get<LinearRing>(poly_i);
+      wkt << std::fixed << std::setprecision(3) << "POLYGON((";
+      for (auto& v : polygon) {
+        wkt << v[0] + (*manager.data_offset)[0] << " "
+            << v[1] + (*manager.data_offset)[1] << ", ";
+      }
+      wkt << polygon[0][0] + (*manager.data_offset)[0] << " "
+          << polygon[0][1] + (*manager.data_offset)[1];
+      wkt << "))" << "\t";
+      wkt << median << std::endl;
+      // end DEBUG
     }
   }
+  // DEBUG: write polygon WKT with ground height to file
+  if (out_tsv.is_open()) {
+    std::cout << "Writing " << fout << std::endl;
+    out_tsv << wkt.str();
+  } else {
+    std::cout << "Could not open " << fout << std::endl;
+  }
+  out_tsv.close();
+  // end DEBUG
 }
 
 void BuildingSelectorNode::process() {

--- a/src/stepedge_nodes.cpp
+++ b/src/stepedge_nodes.cpp
@@ -2283,12 +2283,18 @@ void LASInPolygonsNode::process() {
 
 void EptInPolygonsNode::process()
 {
+  // Prepare inputs
   auto& polygons = vector_input("polygons");
 
+  // Prepare outputs
   auto& point_clouds = vector_output("point_clouds");
   point_clouds.resize<PointCollection>(polygons.size());
-  // auto& color_clouds = vector_output("colors");
-  // color_clouds.resize<vec3f>(polygons.size());
+  auto& ground_heights = vector_output("ground_heights");
+  ground_heights.resize<vec1f>(polygons.size());
+
+  // Intermediary storage for computing median ground heights
+  std::vector<std::vector<float>> point_clouds_ground;
+  point_clouds_ground.resize(polygons.size());
 
   // make a vector of BOX2D for the set of input polygons
   Box completearea_bb;
@@ -2385,6 +2391,7 @@ void EptInPolygonsNode::process()
       float px = view->getFieldAs<float>(pdal::Dimension::Id::X, p) - (*manager.data_offset)[0];
       float py = view->getFieldAs<float>(pdal::Dimension::Id::Y, p) - (*manager.data_offset)[1];
       float pz = view->getFieldAs<float>(pdal::Dimension::Id::Z, p) - (*manager.data_offset)[2];
+      int pclass = view->getFieldAs<int>(pdal::Dimension::Id::Classification, p);
       pPipoint point = new Pipoint{px,py};
 
       // look up grid index cell and do pip for all polygons retreived from that cell
@@ -2393,12 +2400,61 @@ void EptInPolygonsNode::process()
         std::cout << "Point (" << px << ", " <<py << ", "  << pz << ") is not in the polygon bbox.\n";
         continue;
       }
+      // For the ground points we only test if the point is within the grid
+      // index cell, but we do not do a pip for the footprint itself.
+      // The reasons for this:
+      //  - If we would do a pip for with the ground points, we would need to
+      //    have a separate list of buffered footprints that we use for the
+      //    ground pip. Still it would be often the case that there are no
+      //    ground points found for a buffered footprint. Thus we need a larger
+      //    area in which we can guarantee that we find at least a couple of
+      //    ground points.
+      //  - Because we work with Netherlands data, the ground relief is small.
+      //    Thus a single ground height value per grid cell is good enough for
+      //    representing the ground/floor elevation of the buildings in that
+      //    grid cell.
+      bool found_pip(false);
       for(size_t& poly_i : pindex_vals[lincoord]) {
-        if (GridTest(poly_grids[poly_i], point)) {
+        if (pclass == 2) {
+          point_clouds_ground[poly_i].push_back(pz);
+        } else if (not found_pip and GridTest(poly_grids[poly_i], point)) {
           point_clouds.get<PointCollection&>(poly_i).push_back({px, py, pz});
-          break;
+          found_pip = true;
         }
       }
+    }
+  }
+
+  // Compute median ground height per grid cell and store it for each polygon
+  std::cout <<"Computing the median ground elevation in the grid cells" << std::endl;
+  for (auto& cell : pindex_vals) {
+    std::vector<float> z_vec;
+    for (size_t& poly_i : cell) {
+      for (float& pz : point_clouds_ground[poly_i]) {
+        z_vec.push_back(pz);
+      }
+    }
+    float median;
+    // Median for odd-number of elements
+    if (z_vec.size() % 2 > 0) {
+      size_t n = z_vec.size() / 2;
+      std::nth_element(z_vec.begin(), z_vec.begin()+n, z_vec.end());
+      median = z_vec[n];
+    }
+    // even-number of elements
+    else {
+      float m0, m1;
+      size_t n = z_vec.size() / 2;
+      std::nth_element(z_vec.begin(), z_vec.begin()+n, z_vec.end());
+      m0 = z_vec[n];
+      n++;
+      std::nth_element(z_vec.begin(), z_vec.begin()+n, z_vec.end());
+      m1 = z_vec[n];
+      median = (m0 + m1) / 2;
+    }
+    // Assign the median ground elevation to each polygon
+    for (size_t& poly_i : cell) {
+      ground_heights.get<vec1f>(poly_i).push_back(median);
     }
   }
 }

--- a/src/stepedge_nodes.hpp
+++ b/src/stepedge_nodes.hpp
@@ -523,7 +523,7 @@ namespace geoflow::nodes::stepedge {
 
   class EptInPolygonsNode:public Node {
     std::string dirpath = "";
-    std::string filter_limits = "Classification[6:6]";
+    std::string filter_limits = "Classification[2:2],Classification[6:6]";
     float cellsize = 50.0;
     float buffer = 1.0;
   public:
@@ -531,7 +531,7 @@ namespace geoflow::nodes::stepedge {
     void init() {
       add_vector_input("polygons", typeid(LinearRing));
       add_vector_output("point_clouds", typeid(PointCollection));
-      add_vector_output("colors", typeid(vec3f));
+      add_vector_output("ground_heights", typeid(vec1f));
 
       add_param("dirpath", ParamPath(dirpath, "EPT directory"));
       add_param("filter_limits", ParamString(filter_limits, "PDAL Range filter"));


### PR DESCRIPTION
Read the ground points (class 2). Only test if the point is within the grid
index cell, but do not do a pip for the footprint itself.
When all ground point are read for the grid, compute the median Z per cell.
Output the median ground elevation for each polygon in the `ground_heights` output, which is a vector of floats.

I verified the ground height calculation by comparing the calculated values to a 'reference'. The 'reference' is the median ground height that was calculated from the AHN3 0.5m DTM with footprints with 2m buffer. I checked 30 buildings in a small area in Rotterdam:

```
POLYGON ((93027.69800000000395812 434063.18599999998696148, 93199.97500000000582077 434063.18599999998696148, 93199.97500000000582077 434237.45899999997345731, 93027.69800000000395812 434237.45899999997345731, 93027.69800000000395812 434063.18599999998696148))
```
The absolute difference in meters between these median heights and the 'reference' is:

'MAX': 0.21,
'MEAN': 0.07,
'MEDIAN': 0.06,
'STD_DEV': 0.05,

So I think its fine :smile: 

Note: I only implemented in the Ept-reader node, because I assume we'll keep using PDAL. For impelemting #4, I think we can take the Ept-node and simply replace the EPT reader with a LAS reader.

Closes #5